### PR TITLE
Add in-place sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ docker run -d \
 | `--one-time`               | GIT_SYNC_ONE_TIME               | false                         | exit after the first sync |
 | `--max-sync-failures`      | GIT_SYNC_MAX_SYNC_FAILURES      | 0                             | the number of consecutive failures allowed before aborting (the first sync must succeed, -1 will retry forever after the initial sync) |
 | `-v`                       | (none)                          | ""                            | log level for V logs |
+| `--in-place`               | GIT_SYNC_IN_PLACE               | false                         | update the worktree in place instead of swapping a symlink |
 
 
 ## Flags which control how git runs


### PR DESCRIPTION
Add in-place sync using the `--in-place` flag and `GIT_SYNC_IN_PLACE` env variable, which modifies git-sync's behavior:
- it checks out a single worktree at `dest`.
- it syncs (`git resets`) every change in this single workspace.

The original behavior checked out a separate workspace for each hash, and did a symlink replace on `dest` to ensure  atomicity. This however invalidates volume mounts to any children of the symlink, making it impossible to use a subdirectory in the repo as the mount point in another container.